### PR TITLE
initial stab at LogContext

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly IFunctionInstanceLogger _functionInstanceLogger;
         private readonly IFunctionOutputLogger _functionOutputLogger;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
-        private readonly TraceWriter _trace;
+        private readonly LogContext _logContext;
         private readonly IAsyncCollector<FunctionInstanceLogEntry> _functionEventCollector;
         private readonly ILogger _logger;
         private readonly ILogger _resultsLogger;
@@ -35,38 +35,36 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private HostOutputMessage _hostOutputMessage;
 
         public FunctionExecutor(IFunctionInstanceLogger functionInstanceLogger, IFunctionOutputLogger functionOutputLogger,
-                IWebJobsExceptionHandler exceptionHandler, TraceWriter trace, IAsyncCollector<FunctionInstanceLogEntry> functionEventCollector = null,
-                ILoggerFactory loggerFactory = null)
+                IWebJobsExceptionHandler exceptionHandler, LogContext logContext, IAsyncCollector<FunctionInstanceLogEntry> functionEventCollector = null)
         {
             if (functionInstanceLogger == null)
             {
-                throw new ArgumentNullException("functionInstanceLogger");
+                throw new ArgumentNullException(nameof(functionInstanceLogger));
             }
 
             if (functionOutputLogger == null)
             {
-                throw new ArgumentNullException("functionOutputLogger");
+                throw new ArgumentNullException(nameof(functionOutputLogger));
             }
 
             if (exceptionHandler == null)
             {
-                throw new ArgumentNullException("exceptionHandler");
+                throw new ArgumentNullException(nameof(exceptionHandler));
             }
 
-            if (trace == null)
+            if (logContext == null)
             {
-                throw new ArgumentNullException("trace");
+                throw new ArgumentNullException(nameof(logContext));
             }
-
             _functionInstanceLogger = functionInstanceLogger;
             _functionOutputLogger = functionOutputLogger;
             _exceptionHandler = exceptionHandler;
-            _trace = trace;
+            _logContext = logContext;
             _functionEventCollector = functionEventCollector;
-            _logger = loggerFactory?.CreateLogger(LogCategories.Executor);
-            _resultsLogger = loggerFactory?.CreateLogger(LogCategories.Results);
+            _logger = _logContext.LoggerFactory?.CreateLogger(LogCategories.Executor);
+            _resultsLogger = _logContext.LoggerFactory?.CreateLogger(LogCategories.Results);
         }
-
+        
         public HostOutputMessage HostOutputMessage
         {
             get { return _hostOutputMessage; }
@@ -229,7 +227,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 {
                     // We create a new composite trace writer that will also forward
                     // output to the function output log (in addition to console, user TraceWriter, etc.).                    
-                    TraceWriter functionTraceWriter = new FunctionInstanceTraceWriter(instance, HostOutputMessage.HostInstanceId, _trace, functionTraceLevel);
+                    TraceWriter functionTraceWriter = new FunctionInstanceTraceWriter(instance, HostOutputMessage.HostInstanceId, _logContext.TraceWriter, functionTraceLevel);
                     TraceWriter traceWriter = new CompositeTraceWriter(functionTraceWriter, functionOutputTextWriter, functionTraceLevel);
 
                     // Must bind before logging (bound invoke string is included in log message).

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Loggers;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
@@ -16,33 +15,30 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly IFunctionIndexLookup _functionLookup;
         private readonly IFunctionExecutor _executor;
         private readonly IListener _listener;
-        private readonly TraceWriter _trace;
+        private readonly LogContext _logContext;
         private readonly IAsyncCollector<FunctionInstanceLogEntry> _functionEventCollector; // optional        
-        private readonly ILoggerFactory _loggerFactory;
 
         private bool _disposed;
 
         public JobHostContext(IFunctionIndexLookup functionLookup,
             IFunctionExecutor executor,
             IListener listener,
-            TraceWriter trace,
-            IAsyncCollector<FunctionInstanceLogEntry> functionEventCollector = null,
-            ILoggerFactory loggerFactory = null)
+            LogContext logContext,
+            IAsyncCollector<FunctionInstanceLogEntry> functionEventCollector = null)
         {
             _functionLookup = functionLookup;
             _executor = executor;
             _listener = listener;
-            _trace = trace;
+            _logContext = logContext;
             _functionEventCollector = functionEventCollector;
-            _loggerFactory = loggerFactory;
         }
 
-        public TraceWriter Trace
+        public LogContext LogContext
         {
             get
             {
                 ThrowIfDisposed();
-                return _trace;
+                return _logContext;
             }
         }
 
@@ -82,21 +78,12 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             }
         }
 
-        public ILoggerFactory LoggerFactory
-        {
-            get
-            {
-                ThrowIfDisposed();
-                return _loggerFactory;
-            }
-        }
-
         public void Dispose()
         {
             if (!_disposed)
             {
                 _listener.Dispose();
-                _loggerFactory?.Dispose();
+                _logContext?.Dispose();
 
                 _disposed = true;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
@@ -14,7 +14,6 @@ using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
 
 namespace Microsoft.Azure.WebJobs
@@ -47,8 +46,6 @@ namespace Microsoft.Azure.WebJobs
         private Task _stopTask;
         private object _stopTaskLock = new object();
         private bool _disposed;
-
-        private ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JobHost"/> class, using a Microsoft Azure Storage connection
@@ -119,9 +116,7 @@ namespace Microsoft.Azure.WebJobs
 
             await _listener.StartAsync(cancellationToken);
 
-            string msg = "Job host started";
-            _context.Trace.Info(msg, Host.TraceSource.Host);
-            _logger?.LogInformation(msg);
+            _context.LogContext.LogInformation(LogCategories.Startup, "Job host started");
 
             _state = StateStarted;
         }
@@ -169,9 +164,7 @@ namespace Microsoft.Azure.WebJobs
                 await functionEventCollector.FlushAsync(cancellationToken);
             }
 
-            string msg = "Job host stopped";
-            _context.Trace.Info(msg, Host.TraceSource.Host);
-            _logger?.LogInformation(msg);
+            _context.LogContext.LogInformation(LogCategories.Startup, "Job host Stopped");
         }
 
         /// <summary>Runs the host and blocks the current thread while the host remains running.</summary>
@@ -341,8 +334,6 @@ namespace Microsoft.Azure.WebJobs
                     _listener = context.Listener;
                 }
             }
-
-            _logger = _context.LoggerFactory?.CreateLogger(LogCategories.Startup);
 
             return _context;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/LogContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/LogContext.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Host.Loggers
+{
+    internal class LogContext : IDisposable
+    {
+        private bool _disposed = false;
+
+        public LogContext(TraceWriter trace, ILoggerFactory loggerFactory)
+        {
+            TraceWriter = trace;
+            LoggerFactory = loggerFactory;
+        }
+
+        public ILoggerFactory LoggerFactory { get; private set; }
+
+        public TraceWriter TraceWriter { get; private set; }
+
+        public void LogInformation(string category, string message)
+        {
+            TraceWriter?.Info(message, source: category);
+            LoggerFactory?.CreateLogger(category).LogInformation(message);
+        }
+
+        public void LogWarning(string category, string message)
+        {
+            TraceWriter?.Warning(message, source: category);
+            LoggerFactory?.CreateLogger(category).LogWarning(message);
+        }
+
+        public void LogDebug(string category, string message)
+        {
+            TraceWriter?.Verbose(message, source: category);
+            LoggerFactory?.CreateLogger(category).LogDebug(message);
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                LoggerFactory?.Dispose();
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -497,6 +497,7 @@
     <Compile Include="Exceptions\RecoverableException.cs" />
     <Compile Include="JobHostBlobsConfiguration.cs" />
     <Compile Include="Listeners\FunctionListener.cs" />
+    <Compile Include="Loggers\LogContext.cs" />
     <Compile Include="Loggers\Logger\Aggregator\FunctionResultAggregatorConfiguration.cs" />
     <Compile Include="Loggers\Logger\Aggregator\FunctionResultAggregate.cs" />
     <Compile Include="Loggers\Logger\Aggregator\FunctionResultAggregator.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             IFunctionOutputLoggerProvider outputLoggerProvider = new NullFunctionOutputLoggerProvider();
             IFunctionOutputLogger outputLogger = outputLoggerProvider.GetAsync(CancellationToken.None).Result;
 
-            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, exceptionHandler, logger);
+            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, exceptionHandler, new LogContext(logger, null));
 
             return new FunctionIndexer(triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor,
                 extensionRegistry, singletonManager, logger, loggerFactory);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -28,15 +29,17 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             mockListener.Setup(p => p.Dispose());
             mockLoggerFactory.Setup(p => p.Dispose());
 
-            var context = new JobHostContext(mockLookup.Object, mockExecutor.Object, mockListener.Object, traceWriter, loggerFactory: mockLoggerFactory.Object);
+            var logContext = new LogContext(traceWriter, mockLoggerFactory.Object);
 
-            Assert.Same(traceWriter, context.Trace);
+            var context = new JobHostContext(mockLookup.Object, mockExecutor.Object, mockListener.Object, logContext);
+
+            Assert.Same(traceWriter, logContext.TraceWriter);
 
             context.Dispose();
 
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                context.Trace.Info("Kaboom!");
+                context.LogContext.TraceWriter.Info("Kaboom!");
             });
 
             // verify that calling Dispose again is a noop


### PR DESCRIPTION
I wanted to share this for some opinions before I start plumbing it through everywhere. A couple reasons I didn't do this at first:

- The functionality between TraceWriter and ILoggerFactory/ILogger is different enough that its tough to write a wrapper that really handles everything nicely (i.e. Scopes, object lifetime, categories are all handled differently)
- With TraceWriter going away at some point in the future, this type will also go away, meaning we'll still have to update all of our signatures (unless we keep a wrapper around for a single type, which feels weird).

We could just have the LogContext hold the TraceWriter and ILogger factory, which simplifies the signatures, but doesn't simplify the actual logging calls.

I've called out a few things in comments below.
